### PR TITLE
Add redirects created by script

### DIFF
--- a/content/community/behavior/making-a-coc-complaint/contents.lr
+++ b/content/community/behavior/making-a-coc-complaint/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/community/behavior/making-a-coc-report/contents.lr
+---
+_discoverable: no

--- a/content/community/team/cflee/contents.lr
+++ b/content/community/team/cflee/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/cflee/contents.lr
+---
+_discoverable: no

--- a/content/community/team/danyeaw/contents.lr
+++ b/content/community/team/danyeaw/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/danyeaw/contents.lr
+---
+_discoverable: no

--- a/content/community/team/elias/contents.lr
+++ b/content/community/team/elias/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/elias/contents.lr
+---
+_discoverable: no

--- a/content/community/team/flowerncsu/contents.lr
+++ b/content/community/team/flowerncsu/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/flowerncsu/contents.lr
+---
+_discoverable: no

--- a/content/community/team/freakboy3742/contents.lr
+++ b/content/community/team/freakboy3742/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/freakboy3742/contents.lr
+---
+_discoverable: no

--- a/content/community/team/glasnt/contents.lr
+++ b/content/community/team/glasnt/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/glasnt/contents.lr
+---
+_discoverable: no

--- a/content/community/team/hawkowl/contents.lr
+++ b/content/community/team/hawkowl/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/hawkowl/contents.lr
+---
+_discoverable: no

--- a/content/community/team/mhsmith/contents.lr
+++ b/content/community/team/mhsmith/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/mhsmith/contents.lr
+---
+_discoverable: no

--- a/content/community/team/obulat/contents.lr
+++ b/content/community/team/obulat/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/obulat/contents.lr
+---
+_discoverable: no

--- a/content/community/team/phildini/contents.lr
+++ b/content/community/team/phildini/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/phildini/contents.lr
+---
+_discoverable: no

--- a/content/community/team/rmartin16/contents.lr
+++ b/content/community/team/rmartin16/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/rmartin16/contents.lr
+---
+_discoverable: no

--- a/content/community/team/samschott/contents-de.lr
+++ b/content/community/team/samschott/contents-de.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/samschott/contents-de.lr
+---
+_discoverable: no

--- a/content/community/team/samschott/contents.lr
+++ b/content/community/team/samschott/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/samschott/contents.lr
+---
+_discoverable: no

--- a/content/community/team/saroad2/contents.lr
+++ b/content/community/team/saroad2/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/saroad2/contents.lr
+---
+_discoverable: no

--- a/content/community/team/swenson/contents.lr
+++ b/content/community/team/swenson/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/team/swenson/contents.lr
+---
+_discoverable: no

--- a/content/contact/contents.lr
+++ b/content/contact/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/contact/contents.lr
+---
+_discoverable: no

--- a/content/contact/media/contents.lr
+++ b/content/contact/media/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/about/contact/media/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/github-notifications-101/contents.lr
+++ b/content/contributing/how/first-time/github-notifications-101/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/github-notifications-101/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/github/contents.lr
+++ b/content/contributing/how/first-time/github/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/github/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/imposter-syndrome/contents.lr
+++ b/content/contributing/how/first-time/imposter-syndrome/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/imposter-syndrome/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/more/contents.lr
+++ b/content/contributing/how/first-time/more/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/more/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/setting-up-your-environment/contents.lr
+++ b/content/contributing/how/first-time/setting-up-your-environment/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/setting-up-your-environment/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/what-is-a/ci/contents.lr
+++ b/content/contributing/how/first-time/what-is-a/ci/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/what-is-a/ci/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/what-is-a/contents.lr
+++ b/content/contributing/how/first-time/what-is-a/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/what-is-a/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/what-is-a/git/contents.lr
+++ b/content/contributing/how/first-time/what-is-a/git/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/what-is-a/git/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/what-is-a/package-manager/contents.lr
+++ b/content/contributing/how/first-time/what-is-a/package-manager/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/what-is-a/package-manager/contents.lr
+---
+_discoverable: no

--- a/content/contributing/how/first-time/what/contents.lr
+++ b/content/contributing/how/first-time/what/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/contributing/first-time/what/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/applications/podium/contents.lr
+++ b/content/project/projects/applications/podium/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/applications/podium/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/batavia/contents.lr
+++ b/content/project/projects/attic/batavia/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/batavia/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/cassowary/contents.lr
+++ b/content/project/projects/attic/cassowary/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/cassowary/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/contents.lr
+++ b/content/project/projects/attic/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/cookiecutter-project/contents.lr
+++ b/content/project/projects/attic/cookiecutter-project/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/cookiecutter-project/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/cookiecutter-website/contents.lr
+++ b/content/project/projects/attic/cookiecutter-website/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/cookiecutter-website/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/python-ios-support/contents.lr
+++ b/content/project/projects/attic/python-ios-support/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-ios-support/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/python-osx-support/contents.lr
+++ b/content/project/projects/attic/python-osx-support/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-osx-support/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/python-tvos-support/contents.lr
+++ b/content/project/projects/attic/python-tvos-support/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-tvos-support/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/sealang/contents.lr
+++ b/content/project/projects/attic/sealang/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/sealang/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/seasnake/contents.lr
+++ b/content/project/projects/attic/seasnake/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/seasnake/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/trebuchet/contents.lr
+++ b/content/project/projects/attic/trebuchet/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/trebuchet/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/voc/contents.lr
+++ b/content/project/projects/attic/voc/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/voc/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/attic/waggle/contents.lr
+++ b/content/project/projects/attic/waggle/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/waggle/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/bridges/rubicon/contents.lr
+++ b/content/project/projects/bridges/rubicon/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/utilities/rubicon/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/libraries/colosseum/contents.lr
+++ b/content/project/projects/libraries/colosseum/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/utilities/colosseum/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/libraries/ouroboros/contents.lr
+++ b/content/project/projects/libraries/ouroboros/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/ouroboros/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/libraries/toga/contents.lr
+++ b/content/project/projects/libraries/toga/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/toga/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/libraries/travertino/contents.lr
+++ b/content/project/projects/libraries/travertino/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/utilities/travertino/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/support/python-android-support/contents.lr
+++ b/content/project/projects/support/python-android-support/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-android-support/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/support/python-apple-support/contents.lr
+++ b/content/project/projects/support/python-apple-support/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/utilities/python-apple-support/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/support/python-linux-support/contents.lr
+++ b/content/project/projects/support/python-linux-support/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-linux-support/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/templates/python-android-template/contents.lr
+++ b/content/project/projects/templates/python-android-template/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-android-template/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/templates/python-ios-template/contents.lr
+++ b/content/project/projects/templates/python-ios-template/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-ios-template/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/templates/python-macos-template/contents.lr
+++ b/content/project/projects/templates/python-macos-template/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-macos-template/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/templates/python-tvos-template/contents.lr
+++ b/content/project/projects/templates/python-tvos-template/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/python-tvos-template/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/beefore/contents.lr
+++ b/content/project/projects/tools/beefore/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/beefore/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/beekeeper/contents.lr
+++ b/content/project/projects/tools/beekeeper/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/attic/beekeeper/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/briefcase/contents.lr
+++ b/content/project/projects/tools/briefcase/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/briefcase/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/bugjar/contents.lr
+++ b/content/project/projects/tools/bugjar/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/applications/bugjar/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/cricket/contents.lr
+++ b/content/project/projects/tools/cricket/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/applications/cricket/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/duvet/contents.lr
+++ b/content/project/projects/tools/duvet/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/applications/duvet/contents.lr
+---
+_discoverable: no

--- a/content/project/projects/tools/galley/contents.lr
+++ b/content/project/projects/tools/galley/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+new_path: content/project/applications/galley/contents.lr
+---
+_discoverable: no


### PR DESCRIPTION
Script: https://gist.github.com/jepler/126cbf31ff349be62d453d102aa68634

"git diff --name-status {base}...{branch}" prints several different kinds of lines: "A" for files that git thinks were added, "D" for files git thinks were deleted, and "R" for files git thinks were renamed.

(git doesn't actually RECORD if a file is renamed; instead, it looks at the similarity of pairs of added & deleted files; if they're "similar enough" git says "oh it must be a rename". So it's possible for this to simply be wrong especially if multiple files have similar contents.)

This program parses the git diff output for "R" lines and creates redirects; for "D" lines it prints a note that maybe human action is required. In reality, you probably also need to check each of the created redirects, because they could be incorrect due to git guessing about renaming.
files with "+" in the name are skipped (translations) and only files ending ".lr" are checked.
